### PR TITLE
fix(IconDropdown): :bug: replace divs with buttons for better accessi…

### DIFF
--- a/frontend/src/shared/components/ui/Fields/IconDropdown.js
+++ b/frontend/src/shared/components/ui/Fields/IconDropdown.js
@@ -14,7 +14,7 @@ const IconDropdown = ({label, name, value, onChange, options = []}) => {
     return (
         <div className="mb-4 relative z-10">
             <label className="block mb-2 text-sm font-medium text-gray-900">{label}</label>
-            <div
+            <button
                 className="flex items-center justify-between p-2 border rounded-md bg-white cursor-pointer shadow-sm"
                 onClick={() => setShow(!show)}
             >
@@ -23,19 +23,19 @@ const IconDropdown = ({label, name, value, onChange, options = []}) => {
                     {selectedOption?.label || "Seleccione un icono"}
                 </span>
                 <span className="text-gray-400"> <FiChevronDown size={20}/></span>
-            </div>
+            </button>
 
             {show && (
                 <div className="absolute w-full mt-1 bg-white border rounded-md shadow-md max-h-60 overflow-y-auto">
                     {options.map((option, index) => (
-                        <div
+                        <button
                             key={index}
                             onClick={() => handleSelect(option.value)}
                             className="flex items-center gap-2 p-2 cursor-pointer hover:bg-gray-100"
                         >
                             {option.icon}
                             <span className="text-gray-700">{option.label}</span>
-                        </div>
+                        </button>
                     ))}
                 </div>
             )}


### PR DESCRIPTION
This pull request updates the `IconDropdown` component to improve accessibility by replacing non-semantic `div` elements with semantic `button` elements for interactive elements.

### Accessibility improvements:

* Replaced the outer dropdown toggle `div` with a `button` element to ensure proper semantic usage and keyboard accessibility. (`frontend/src/shared/components/ui/Fields/IconDropdown.js`, [[1]](diffhunk://#diff-6cde299cf5eb2a20650a100f0d9409fea0615e6fa386ac9707ee158325255fecL17-R17) [[2]](diffhunk://#diff-6cde299cf5eb2a20650a100f0d9409fea0615e6fa386ac9707ee158325255fecL26-R38)
* Replaced each dropdown option `div` with a `button` element to make them accessible and interactive in a semantically correct way. (`frontend/src/shared/components/ui/Fields/IconDropdown.js`, [frontend/src/shared/components/ui/Fields/IconDropdown.jsL26-R38](diffhunk://#diff-6cde299cf5eb2a20650a100f0d9409fea0615e6fa386ac9707ee158325255fecL26-R38))…bility and interaction